### PR TITLE
Make websocket headers case insensitive, better cookie header handling

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -1,4 +1,4 @@
-//#define DEBUGGING
+#define DEBUGGING
 
 #include "global.h"
 #include "WebSocketClient.h"

--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -1,4 +1,4 @@
-#define DEBUGGING
+//#define DEBUGGING
 
 #include "global.h"
 #include "WebSocketClient.h"

--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -155,11 +155,12 @@ bool WebSocketClient::analyzeRequest() {
                 serverKey = temp.substring(22,temp.length() - 2); // Don't save last CR+LF
             } else if (!foundsid && tempLC.startsWith("set-cookie: ")) {
                  foundsid = true;
+                 String tempsid;
                  if (temp.indexOf(";") == -1){ // looks for ";" in cookie header, which indicates more than one cookie value
-                   String tempsid = temp.substring(temp.indexOf("=") + 1, temp.length() - 2); // Don't save last CR+LF
+                   tempsid = temp.substring(temp.indexOf("=") + 1, temp.length() - 2); // Don't save last CR+LF
                  }
                  else {
-                   String tempsid = temp.substring(temp.indexOf("=") + 1, temp.indexOf(";")); // assumes sid is first cookie value, discards all other values
+                   tempsid = temp.substring(temp.indexOf("=") + 1, temp.indexOf(";")); // assumes sid is first cookie value, discards all other values
                  }
                  strcpy(sid, tempsid.c_str());
                  #ifdef DEBUGGING


### PR DESCRIPTION
- Per Websocket/HTTP spec, updated to allow case-insensitivity in websocket/HTTP headers 
- Updated "set-cookie" header to allow for multiple cookie values, saving first one as sid
- Add debug code to print client websocket request headers
